### PR TITLE
yomitaiディレクトリからdockerを使用するよう変更

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,23 @@
+# .devcontainer/Dockerfile
+FROM python:3.9
+
+# 環境変数を設定
+ENV PYTHONUNBUFFERED 1
+
+# cronと必要なパッケージをインストール
+RUN apt-get update && apt-get install -y cron \
+  && pip install poetry sqlalchemy pymysql alembic mysqlclient passlib
+
+# 作業ディレクトリを設定
+WORKDIR /workspace
+
+# 依存関係をインストール
+COPY ./backend/pyproject.toml /workspace/
+RUN poetry config virtualenvs.create false \
+  && poetry install --no-interaction --no-ansi
+
+# ホストマシンのファイルをコピー
+COPY . /workspace
+
+# FastAPI の起動コマンド (オーバーライド可能)
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--reload"]

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -2,7 +2,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-SQLALCHEMY_DATABASE_URL = "mysql+pymysql://mysql:mysql@db:3306/yomitai?charset=utf8mb4"
+SQLALCHEMY_DATABASE_URL = "mysql+pymysql://mysql:mysql@yomitai_local_db:3306/yomitai?charset=utf8mb4"
 
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -102,6 +102,7 @@ class Award(Base):
     __tablename__ = "awards"
 
     id = Column(Integer, primary_key=True, index=True)
+    award_name = Column(String(255), nullable=False)
     award_type = Column(String(255), nullable=False)
     award_criteria = Column(Integer, nullable=False)
     created_at = Column(DateTime, default=datetime.now(), nullable=False)

--- a/backend/app/routers/get_dashboard.py
+++ b/backend/app/routers/get_dashboard.py
@@ -48,13 +48,16 @@ def get_dashboard(request: Request, db: Session = Depends(get_db)):
     unique_date = set(reading_date_list)
     reading_date=list(unique_date)
 
-    # user_awardsのdateリストを取得
-    award_date_list = [award.date for award in db.query(models.User_award.award_date).filter(models.User_award.user_id == user_id).all()]
+    # # user_awardsのdateリストを取得
+    # award_date_list = [award.date for award in db.query(models.User_award.award_date).filter(models.User_award.user_id == user_id).all()]
+    # award_list = [award.date for award in award_date_list]
+    # award_unique_date = set(award_list)
+    # award_date = list(award_unique_date)
 
     response = {
         "dashboard": dashboard_list,
         "reading_dates": reading_date,
-        "award_dates": award_date_list
+        # "award_dates": award_date
     }
 
     return response

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -98,8 +98,9 @@ class ReadBookRequest(BaseModel):
 
 
 class Award(BaseModel):
+    award_name: str
     award_type: str
-    award_criteria:int
+    award_criteria: int
     created_at: datetime
     updated_at: datetime
 

--- a/backend/log/cron.log
+++ b/backend/log/cron.log
@@ -1,43 +1,15 @@
-Traceback (most recent call last):
-  File "/workspaces/yomitai/backend/app/notifications.py", line 3, in <module>
-    from models import Reading_session, Book, Daily_log, User
-  File "/workspaces/yomitai/backend/app/models.py", line 6, in <module>
-    from .database import Base
-ImportError: attempted relative import with no known parent package
-Traceback (most recent call last):
-  File "/workspaces/yomitai/backend/app/notifications.py", line 3, in <module>
-    from models import Reading_session, Book, Daily_log, User
-  File "/workspaces/yomitai/backend/app/models.py", line 6, in <module>
-    from .database import Base
-ImportError: attempted relative import with no known parent package
-Traceback (most recent call last):
-  File "/workspaces/yomitai/backend/app/notifications.py", line 3, in <module>
-    from app.models import Reading_session, Book, Daily_log, User, My_book
-ModuleNotFoundError: No module named 'app'
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
-Error response from daemon: container 9849c25cd6cecfb2cb8d24783fa0f6bee71c3f5f6f01c8e9cf38018dd95e96e4 is not running
+Error response from daemon: container 5f468c6d8383cc2f11ae062d16f4c5b216b94300d1810547c458cda491e12f3d is not running
+Error response from daemon: container 5f468c6d8383cc2f11ae062d16f4c5b216b94300d1810547c458cda491e12f3d is not running
 Error response from daemon: No such container: yomitai_app
-Error response from daemon: container debfaece255608b8dc75e6d6545c914a2bececc7009364eb745c2e7caaf4bb6b is not running
+Error response from daemon: No such container: yomitai_app
+Error response from daemon: No such container: yomitai_app
+Error response from daemon: No such container: yomitai_app
+Error response from daemon: No such container: yomitai_app
+Error response from daemon: No such container: yomitai_app
+Error response from daemon: No such container: yomitai_app
+Error response from daemon: No such container: yomitai_app
+Error response from daemon: No such container: yomitai_app
+Error response from daemon: No such container: yomitai_app
+Error response from daemon: No such container: yomitai_app
+Error response from daemon: No such container: yomitai_app
+Error response from daemon: No such container: yomitai_app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,16 +3,16 @@
 services:
   yomitai_local_db:
     container_name: yomitai_local_db
-    image: mysql:latest
+    image: mysql:8.0
     restart: unless-stopped
     volumes:
       - mysql-data:/var/lib/mysql
       - ./backend/db/init.sql:/docker-entrypoint-initdb.d/init.sql
       - ./backend/db/my.cnf:/etc/mysql/conf.d/my.cnf
-    # ports:
-    #   - "5432:5432"
-    expose:
-      - "3306"
+    ports:
+      - "3306:3306"
+    # expose:
+    #   - "3306"
     environment:
       MYSQL_ROOT_PASSWORD: mysql
       MYSQL_DB: mysql
@@ -22,10 +22,10 @@ services:
       MYSQL_COLLATION_SERVER: 'utf8mb4_unicode_ci'
 
   yomitai_backend:
-    container_name: fastapi
+    container_name: yomitai_backend
     build:
       context: .
-      dockerfile: ./backend/.devcontainer/Dockerfile
+      dockerfile: ./backend/Dockerfile
     volumes:
       - ./backend:/backend
     ports:
@@ -34,25 +34,22 @@ services:
     command: >
       /bin/sh -c '
       cd backend/ &&
-      uvicorn app.main:app --host 0.0.0.0
+      uvicorn app.main:app --host 0.0.0.0 --port 8000
       '
     depends_on:
       - yomitai_local_db
 
 
-  # frontend:
-  #   container_name: react
-  #   build:
-  #     context: .
-  #     dockerfile: ./frontend/Dockerfile
-  #   volumes:
-  #     - ./front/app:/app
-  #     - /React/node_modules
-  #   ports:
-  #     - "5173:5173"  # フロントエンドのポート設定
-  #   tty: true
-  #   command: /bin/sh -c "npm run dev"
-
+  yomitai_frontend:
+    container_name: yomitai_frontend
+    build:
+      context: .
+      dockerfile: ./frontend/Dockerfile
+    volumes:
+      - ./frontend:/frontend
+    ports:
+      - "5173:5173"  # フロントエンドのポート設定
+    tty: true
 
 volumes:
   mysql-data:

--- a/init_sql.sh
+++ b/init_sql.sh
@@ -1,4 +1,8 @@
+init_yomitai.sh
 #!/bin/bash
+
+mysql -u admin -p -h database-1.c3q64gg42kiw.ap-northeast-1.rds.amazonaws.com -P 3306 <<EOF
+-- initdb.sql
 
 -- データベースの作成
 CREATE DATABASE IF NOT EXISTS yomitai;
@@ -253,3 +257,4 @@ INSERT INTO user_awards(user_id,award_id,award_date)value(2,14,'2024-01-10');
 
 -- 権限設定の更新
 FLUSH PRIVILEGES;
+EOF


### PR DESCRIPTION
以下、変更点です。
・yomitaiディレクトリからdocker compose up でuvicorn、DB、Nodeを起動するように変更。（backendディレクトリでdevcontainerを使う従来の方法も可能。ただしコンテナの競合が起きるのでコンテナやイメージの削除が必要）。docker compose up でnpm run devまで含めたかったが、どうしてもエラーが出てしまうのでdocker compose up後、nodeのコンテナ入りnpmのインストールと起動が必要。
・DBのawardsテーブルのカラムを変更（それに伴い関連pythonファイルも修正）。
・RDS用のシェルスクリプトを作成。
・MySQLのバージョン変更。

マージは最初に確認できた人がしてください！