### PR TITLE
[ADD]読書記録モーダルを追加。

### DIFF
--- a/frontend/app/src/components/Header.tsx
+++ b/frontend/app/src/components/Header.tsx
@@ -1,8 +1,10 @@
 import { Link } from "react-router-dom";
+import BookMemoModal from "./bookMemoModalButton";
+import BookMemoModalButton from "./bookMemoModalButton";
 
 function Header() {
   return (
-    <header className="flex flex-row items-center border-b border-gray-200 bg-green-100 p-2 text-gray-700">
+    <header className="flex flex-row items-center border-b border-gray-200 bg-green-100 p-2 text-gray-600">
       <img src="./public/img/Yomitai_Icon2.png" alt="" className="w-16" />
       <nav className="mx-auto flex flex-row items-center ">
         <a
@@ -25,7 +27,8 @@ function Header() {
           </svg>
           ホーム
         </a>
-        <a
+
+        {/* <a
           href="#"
           className="mx-4 flex flex-col items-center hover:text-green-500"
         >
@@ -48,7 +51,7 @@ function Header() {
             />
           </svg>
           記録する
-        </a>
+        </a> */}
 
         <a
           href="graph"
@@ -81,8 +84,8 @@ function Header() {
           className="mx-4 flex flex-col items-center hover:text-green-500"
         >
           <svg
-            width="30"
-            height="30"
+            width="34"
+            height="34"
             viewBox="0 0 24 24"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
@@ -96,15 +99,15 @@ function Header() {
             <path d="M18 6H20V11H18V6Z" fill="currentColor" />
             <path d="M6 6H4V11H6V6Z" fill="currentColor" />
           </svg>
-          ミッション
+          <div className=" text-sm">ミッション</div>
         </a>
         <a
           href="library"
           className="mx-4 flex flex-col items-center hover:text-green-500"
         >
           <svg
-            width="30"
-            height="30"
+            width="32"
+            height="32"
             viewBox="0 0 24 24"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
@@ -116,12 +119,14 @@ function Header() {
               fill="currentColor"
             />
           </svg>
-          ライブラリ
+          <div className=" text-sm">ライブラリ</div>
         </a>
       </nav>
+      <BookMemoModalButton />
+      {/* ↓これにCookieを廃棄するなどのログアウト処理が必要。 */}
       <Link
         to="/login"
-        className="my-2 rounded-xl bg-green-400 px-2 py-1 text-lg text-white duration-300 hover:bg-green-500"
+        className="my-2 rounded-xl bg-green-400 px-2 py-1 text-base text-white duration-300 hover:bg-green-500"
       >
         ログアウト
       </Link>

--- a/frontend/app/src/components/bookMemoModal.tsx
+++ b/frontend/app/src/components/bookMemoModal.tsx
@@ -1,0 +1,146 @@
+import { useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Field,
+  Fieldset,
+  Input,
+  Label,
+  Select,
+  Textarea,
+} from "@headlessui/react";
+import { useBookContext } from "../contexts/bookContext";
+
+interface bookRegisterFormProps {
+  onClose: () => void; // モーダルを閉じる関数
+}
+
+export default function BookMemoModal({ onClose }: bookRegisterFormProps) {
+  const { bookInfo } = useBookContext();
+  const [bookForm, setBookForm] = useState({
+    title: bookInfo.title || "",
+    authors: bookInfo.authors || "",
+    publisher: bookInfo.publisher || "",
+    pages: bookInfo.pages || 0,
+    genre: "",
+    tag: "",
+    date: "",
+    isbn: bookInfo.isbn || "",
+  });
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => {
+    const { name, value } = e.target;
+    setBookForm({ ...bookForm, [name]: value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const response = await fetch("/api/books", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(bookForm),
+      });
+      if (!response.ok) {
+        throw new Error("Network response was not ok");
+      }
+      const result = await response.json();
+      console.log("Success:", result);
+      onClose();
+    } catch (error) {
+      console.error("Error:", error);
+    }
+  };
+
+  return (
+    <>
+      <Dialog open={true} onClose={onClose} className="relative z-50">
+        <div className="fixed inset-0 flex w-screen items-center justify-center bg-black/30 p-4 text-gray-700">
+          <DialogPanel className="flex flex-col rounded-xl bg-cyan-100 md:w-96">
+            <DialogTitle className="m-4 text-center text-lg text-gray-700 underline underline-offset-8">
+              読書記録
+            </DialogTitle>
+            <form onSubmit={handleSubmit}>
+              <Fieldset className="m-2 flex flex-col">
+                <Field className="mx-4 mb-2 flex flex-col">
+                  <Label className="">書籍タイトル</Label>
+                  <Select
+                    className="rounded-lg border p-2"
+                    name="genre"
+                    value={bookForm.genre}
+                    onChange={handleChange}
+                  >
+                    <option value="">選択して下さい</option>
+                    <option value="Tailwind CSS 実践入門">
+                      Tailwind CSS 実践入門
+                    </option>
+                    <option value="リーダブルコード">リーダブルコード</option>
+                  </Select>
+                  {/* <Input
+                    className="w-80 flex-grow rounded-lg border p-2"
+                    name="title"
+                    value={bookForm.title}
+                    onChange={handleChange}
+                  /> */}
+                </Field>
+                <Field className="mx-4 mb-2 flex flex-col">
+                  <Label className="">読み終わったページNo.</Label>
+                  <Input
+                    className="rounded-lg border p-1"
+                    name="authors"
+                    value={bookForm.authors}
+                    onChange={handleChange}
+                  />
+                </Field>
+                <Field className="mx-4 mb-2 flex flex-col">
+                  <Label className="">読書日</Label>
+                  {/* Date pickerを実装する。 */}
+                  <Input
+                    className="rounded-lg border p-1"
+                    name="publisher"
+                    value={bookForm.publisher}
+                    onChange={handleChange}
+                  />
+                </Field>
+                <Field className="mx-4 mb-2 flex flex-col">
+                  <Label className="">タグ</Label>
+                  <Input
+                    className="rounded-lg border p-1"
+                    name="pages"
+                    value={bookForm.tag}
+                    onChange={handleChange}
+                  />
+                </Field>
+                <Field className="mx-4 mb-2 flex flex-col">
+                  <Label className="">メモ</Label>
+                  <Textarea className={"rounded-lg border"} rows={4} />
+                </Field>
+              </Fieldset>
+              <div className="mx-auto flex w-[50%] flex-col">
+                <Button
+                  type="submit"
+                  className="boder-0 m-2 rounded-xl bg-cyan-400 px-6 py-2 text-lg text-white duration-300 hover:bg-cyan-500"
+                >
+                  記録
+                </Button>
+                <Button
+                  type="button"
+                  className="boder-0 m-2 rounded-xl bg-cyan-400 px-6 py-2 text-lg text-white duration-300 hover:bg-cyan-500"
+                  onClick={onClose}
+                >
+                  キャンセル
+                </Button>
+              </div>
+            </form>
+          </DialogPanel>
+        </div>
+      </Dialog>
+    </>
+  );
+}

--- a/frontend/app/src/components/bookMemoModalButton.tsx
+++ b/frontend/app/src/components/bookMemoModalButton.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import BookMemoModal from "./bookMemoModal";
+
+export default function BookMemoModalButton() {
+  const [isMemoModalOpen, setIsMemoModalOpen] = useState(false);
+
+  const openMemoModal = () => {
+    setIsMemoModalOpen(true);
+  };
+
+  return (
+    <>
+      <button
+        className="mx-auto my-2 flex items-center rounded-xl bg-cyan-400 px-2 py-1 text-lg text-white duration-300 hover:bg-cyan-500"
+        onClick={openMemoModal} // ボタンがクリックされた時にモーダルを開く
+      >
+        <svg
+          width="30"
+          height="30"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            fill-rule="evenodd"
+            clip-rule="evenodd"
+            d="M21.2635 2.29289C20.873 1.90237 20.2398 1.90237 19.8493 2.29289L18.9769 3.16525C17.8618 2.63254 16.4857 2.82801 15.5621 3.75165L4.95549 14.3582L10.6123 20.0151L21.2189 9.4085C22.1426 8.48486 22.338 7.1088 21.8053 5.99367L22.6777 5.12132C23.0682 4.7308 23.0682 4.09763 22.6777 3.70711L21.2635 2.29289ZM16.9955 10.8035L10.6123 17.1867L7.78392 14.3582L14.1671 7.9751L16.9955 10.8035ZM18.8138 8.98525L19.8047 7.99429C20.1953 7.60376 20.1953 6.9706 19.8047 6.58007L18.3905 5.16586C18 4.77534 17.3668 4.77534 16.9763 5.16586L15.9853 6.15683L18.8138 8.98525Z"
+            fill="currentColor"
+          />
+          <path
+            d="M2 22.9502L4.12171 15.1717L9.77817 20.8289L2 22.9502Z"
+            fill="currentColor"
+          />
+        </svg>
+        読書記録
+      </button>
+      {/* isBarcodeReaderOpen が true の時に BarcodeReader を表示 */}
+      {isMemoModalOpen && (
+        <BookMemoModal onClose={() => setIsMemoModalOpen(false)} />
+      )}
+    </>
+  );
+}

--- a/frontend/app/src/components/bookRegistModals.tsx
+++ b/frontend/app/src/components/bookRegistModals.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
-import BarcodeReader from "../components/barcodeReader";
-import BookRegisterForm from "../components/bookRegisterForm";
+import BarcodeReader from "./barcodeReader";
+import BookRegisterForm from "./bookRegisterForm";
 
-export default function Modals() {
+export default function BookRegistModals() {
   const [isBarcodeReaderOpen, setIsBarcodeReaderOpen] = useState(false);
   const [isBookRegisterFormOpen, setIsBookRegisterFormOpen] = useState(false);
 
@@ -19,7 +19,7 @@ export default function Modals() {
   return (
     <>
       <button
-        className="boder-0 m-4 rounded-xl bg-green-400 px-6 py-2 text-lg text-white duration-300 hover:bg-green-500"
+        className="my-2 rounded-xl bg-green-400 px-2 py-1 text-lg text-white duration-300 hover:bg-green-500"
         onClick={openBarcodeReader} // ボタンがクリックされた時にモーダルを開く
       >
         書籍登録

--- a/frontend/app/src/main.tsx
+++ b/frontend/app/src/main.tsx
@@ -5,7 +5,7 @@ import "./index.css";
 import Home from "./pages/home";
 import Login from "./pages/login";
 import Signup from "./pages/signup";
-import Modals from "./pages/modals";
+import Modals from "./components/bookRegistModals";
 import { BookProvider } from "./contexts/bookContext";
 import Graph from "./pages/graph";
 import Mission from "./pages/mission";

--- a/frontend/app/src/pages/home.tsx
+++ b/frontend/app/src/pages/home.tsx
@@ -1,6 +1,6 @@
 import Header from "../components/Header";
 import { CalendarComponent } from "../components/calendarComponent";
-import Modals from "./modals";
+import BookRegistModals from "../components/bookRegistModals";
 
 export default function Home() {
   return (
@@ -78,7 +78,7 @@ export default function Home() {
                   </div>
                 </div>
               </div>
-              <Modals />
+              <BookRegistModals />
             </div>
           </div>
         </div>


### PR DESCRIPTION
読書記録モーダルを作成しました。
これの伴い、ヘッダーナビゲーションから”記録する”をボタンとして独立させました。
これはナビゲーションメニューの動きがページ遷移なのに対して、”記録する”がモーダル表示のため、
ナビゲーションのアクションに一貫性を持たせるためのアプローチです。